### PR TITLE
Improve log parser resilience

### DIFF
--- a/Cable Tester Count/uploadTxtFiles.py
+++ b/Cable Tester Count/uploadTxtFiles.py
@@ -1,12 +1,15 @@
 import re
-from openpyxl import load_workbook
 
 def parse_log_file(filepath):
     with open(filepath, 'r') as file:
         content = file.read()
 
     # Correct regex (not double-escaped)
-    match_timestamp = re.search(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+info\s+Test log started", content)
+    match_timestamp = re.search(
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+info\s+Test log started",
+        content,
+        re.IGNORECASE,
+    )
     if not match_timestamp:
         return None
     timestamp = match_timestamp.group(1)
@@ -32,6 +35,7 @@ def parse_log_file(filepath):
     }
 
 def is_already_logged(excel_file, timestamp):
+    from openpyxl import load_workbook
     wb = load_workbook(excel_file)
     for sheet in wb.sheetnames:
         if sheet.startswith("CableTester Logs"):


### PR DESCRIPTION
## Summary
- Avoid global openpyxl dependency by importing within `is_already_logged`
- Make timestamp regex case-insensitive for log parsing

## Testing
- `python -m py_compile 'Cable Tester Count/uploadTxtFiles.py'`
- `python - <<'PY'
from uploadTxtFiles import parse_log_file
print(parse_log_file('logs/ATP_Log_001.log'))
PY`
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68964c55dfb48333ad495af0c03f8b37